### PR TITLE
Fix settings.template.yaml file so as not enter domain twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ File `core/views.py` contain two views. First view needed for setting Webhooks t
 
 - Get token from [@BotFather](https://t.me/BotFather) and insert in `backend/settings.yaml` file (TELEGRAM_TOKEN) section
 
-- Enter your domain name in `backend/settings.yaml` (ALLOWED_HOSTS and WEBHOOK_HOST)
+- Enter your domain name in `backend/settings.yaml` (WEBHOOK_HOST)
 
 - Uncomment `# bot.infinity_polling()` line in `core/bot.py` file
 
@@ -77,7 +77,7 @@ File `core/views.py` contain two views. First view needed for setting Webhooks t
 
 - Get token from [@BotFather](https://t.me/BotFather) and insert in `backend/settings.yaml` file (TELEGRAM_TOKEN) section
 
-- Enter your domain name in `backend/settings.yaml` (ALLOWED_HOSTS and WEBHOOK_HOST)
+- Enter your domain name in `backend/settings.yaml` (WEBHOOK_HOST)
 
 - Create socket file `sudo nano /etc/systemd/system/mytelegrambot.socket`:
 
@@ -173,7 +173,7 @@ server {
 
 - Get token from [@BotFather](https://t.me/BotFather) and insert in `backend/settings.yaml` file (TELEGRAM_TOKEN) section
 
-- Enter your domain name in `backend/settings.yaml` (ALLOWED_HOSTS and WEBHOOK_HOST)
+- Enter your domain name in `backend/settings.yaml` (WEBHOOK_HOST)
 
 - Edit `nginx/default.conf` file and change `mytelegrambot.mydomain.com` to your domain
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = settings['SECRET_KEY']
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = settings['DEBUG']
 
-ALLOWED_HOSTS = settings['ALLOWED_HOSTS']
+ALLOWED_HOSTS = settings['ALLOWED_HOSTS'].append(settings['WEBHOOK_HOST'])
 
 # Application definition
 

--- a/backend/settings.template.yaml
+++ b/backend/settings.template.yaml
@@ -5,6 +5,5 @@ ALLOWED_HOSTS:
   - 127.0.0.1
   - localhost
   - 0.0.0.0
-  - mytelegrambot.mydomain.com
 TELEGRAM_TOKEN: ''
 WEBHOOK_HOST: 'mytelegrambot.mydomain.com'


### PR DESCRIPTION
Fixed settings.template.yaml and settings.py files so as not enter domain twice. Now WEBHOOK_HOST parameter appended in ALLOWED_HOSTS